### PR TITLE
fix: remove dotenv and rename firebase token env variable

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,6 @@
         "axios": "^0.27.2",
         "bootstrap": "^3.4.1",
         "chart.js": "^3.9.1",
-        "dotenv": "^16.0.2",
         "firebase": "^9.10.0",
         "marked": "^4.1.0",
         "react": "^18.2.0",
@@ -7864,14 +7863,6 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/dotenv-expand": {
@@ -25021,11 +25012,6 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
-    },
-    "dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "dotenv-expand": {
       "version": "5.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,6 @@
     "axios": "^0.27.2",
     "bootstrap": "^3.4.1",
     "chart.js": "^3.9.1",
-    "dotenv": "^16.0.2",
     "firebase": "^9.10.0",
     "marked": "^4.1.0",
     "react": "^18.2.0",

--- a/frontend/src/firebase.js
+++ b/frontend/src/firebase.js
@@ -9,7 +9,7 @@ import {
 import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
-  apiKey: process.env.FIREBASE_API_KEY,
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
   authDomain: "peerprep-userser.firebaseapp.com",
   projectId: "peerprep-userser",
   storageBucket: "peerprep-userser.appspot.com",


### PR DESCRIPTION
https://stackoverflow.com/questions/70855580/module-not-found-error-cant-resolve-fs-in-dotenv-lib

- Unable to use dotenv for reading env variables, use React's default way of dealing with environment variables instead.
- Removes dotenv package.